### PR TITLE
Hide hidden files and folders by default

### DIFF
--- a/Sources/FolderBarCore/Scanning/FolderScanner.swift
+++ b/Sources/FolderBarCore/Scanning/FolderScanner.swift
@@ -15,7 +15,7 @@ public struct FolderScanner: Sendable {
         let childURLs = try FileManager.default.contentsOfDirectory(
             at: folderURL,
             includingPropertiesForKeys: Array(resourceKeys),
-            options: []
+            options: [.skipsHiddenFiles]
         )
 
         let items = try childURLs.map { url -> FolderChildItem in


### PR DESCRIPTION
## Summary
Hides hidden files and folders by default. Most people will not want to drag-and-drop these.